### PR TITLE
Add GDP percentile calculation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # fiscal-simulation
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fiscal-simulation",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/gdp.test.js"
+  }
+}

--- a/src/gdp.js
+++ b/src/gdp.js
@@ -1,0 +1,19 @@
+function calculateGDPPercentile(regionGDP, data) {
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error('Data must be a non-empty array');
+  }
+  const sorted = data.slice().sort((a, b) => a - b);
+  let less = 0;
+  let equal = 0;
+  for (const val of sorted) {
+    if (val < regionGDP) {
+      less++;
+    } else if (val === regionGDP) {
+      equal++;
+    }
+  }
+  const percentile = ((less + equal * 0.5) / data.length) * 100;
+  return percentile;
+}
+
+module.exports = { calculateGDPPercentile };

--- a/test/gdp.test.js
+++ b/test/gdp.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { calculateGDPPercentile } = require('../src/gdp');
+
+function nearlyEqual(a, b, tolerance = 1e-6) {
+  return Math.abs(a - b) <= tolerance;
+}
+
+const gdpData = [20000, 25000, 30000, 35000];
+const nationalAverage = gdpData.reduce((a, b) => a + b, 0) / gdpData.length;
+
+assert(nearlyEqual(calculateGDPPercentile(20000, gdpData), 12.5));
+assert(nearlyEqual(calculateGDPPercentile(25000, gdpData), 37.5));
+assert(nearlyEqual(calculateGDPPercentile(30000, gdpData), 62.5));
+assert(nearlyEqual(calculateGDPPercentile(35000, gdpData), 87.5));
+
+assert(nearlyEqual(calculateGDPPercentile(nationalAverage, gdpData), 50));
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- implement `calculateGDPPercentile` in `src/gdp.js`
- add minimal test suite in `test/gdp.test.js`
- wire up npm test script
- update README newline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864f16e8d40832084a72915a50cf701