### PR TITLE
Add economic models and dependency logic

### DIFF
--- a/src/components/SliderGroup.jsx
+++ b/src/components/SliderGroup.jsx
@@ -4,7 +4,7 @@ function SliderGroup({ title, sliders, onChange }) {
   return (
     <div className="p-4">
       <h2 className="font-bold mb-2">{title}</h2>
-      {sliders.map(({ label, value, min, max, step }, index) => (
+      {sliders.map(({ label, value, min, max, step, disabled }, index) => (
         <div key={index} className="mb-4">
           <label className="block mb-1">{label}: {value}</label>
           <input
@@ -15,6 +15,7 @@ function SliderGroup({ title, sliders, onChange }) {
             value={value}
             onChange={(e) => onChange(index, Number(e.target.value))}
             className="w-full"
+            disabled={disabled}
           />
         </div>
       ))}

--- a/src/data/fiscalBaseline.js
+++ b/src/data/fiscalBaseline.js
@@ -21,3 +21,8 @@ export const spendingBaseline = {
   localGov: 60,
   debtInterest: 90,
 };
+
+export const fiscalBaseline = {
+  revenue: revenueBaseline,
+  spending: spendingBaseline,
+};

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -1,6 +1,22 @@
+export function getTotalRevenue(revenue) {
+  return Object.values(revenue).reduce((sum, val) => sum + val, 0);
+}
+
+export function getTotalSpending(spending) {
+  return Object.values(spending).reduce((sum, val) => sum + val, 0);
+}
+
+export function getDeficit(revenue, spending) {
+  return getTotalRevenue(revenue) - getTotalSpending(spending);
+}
+
+export function getDebtInterest(debt, rate = 0.025) {
+  return +(debt * rate).toFixed(1);
+}
+
 export function calculateTotals(revenue, spending, previousDebt = 1000) {
-  const totalRevenue = Object.values(revenue).reduce((a, b) => a + b, 0);
-  const totalSpending = Object.values(spending).reduce((a, b) => a + b, 0);
+  const totalRevenue = getTotalRevenue(revenue);
+  const totalSpending = getTotalSpending(spending);
   const deficit = totalRevenue - totalSpending;
   const nationalDebt = previousDebt - deficit;
   return {

--- a/src/utils/dependencyModel.js
+++ b/src/utils/dependencyModel.js
@@ -1,9 +1,25 @@
-import { revenueBaseline, spendingBaseline } from '../data/fiscalBaseline';
+import { lafferCurve, gdpBoostFromSpending } from './economics';
+import { fiscalBaseline } from '../data/fiscalBaseline';
 
-export const dependencyModel = {
-  baselineInfrastructure: spendingBaseline.infrastructure,
-  baselineUnemployment: spendingBaseline.unemployment,
-  gdpBoostPerInfrastructure: 0.1,
-  gdpVatMultiplier: 0.6,
-  employmentPenaltyRate: 0.2,
-};
+// Main function to apply dependency effects between sliders
+export function applyDependencies(state) {
+  const newState = JSON.parse(JSON.stringify(state)); // Deep clone for safety
+
+  // Example: Keynesian GDP boost from infrastructure
+  const extraInfra =
+    newState.spending.infrastructure - fiscalBaseline.spending.infrastructure;
+  if (extraInfra > 0) {
+    const gdpBoost = gdpBoostFromSpending(extraInfra);
+
+    // Apply simplified GDP effect to VAT and income tax
+    newState.revenue.vat += gdpBoost * 0.5;
+    newState.revenue.incomeTax += gdpBoost * 0.3;
+  }
+
+  // Example: Laffer Curve effect on income tax revenue
+  const taxRate = newState.sliderState?.incomeTaxRate || 0.45; // e.g. 0.45 = 45%
+  const estimatedMax = 350; // theoretical max revenue at optimal rate
+  newState.revenue.incomeTax = lafferCurve(taxRate) * estimatedMax;
+
+  return newState;
+}

--- a/src/utils/economics.js
+++ b/src/utils/economics.js
@@ -1,0 +1,19 @@
+// src/utils/economics.js
+
+// Laffer Curve: Models diminishing returns on high tax rates
+export function lafferCurve(rate, maxRevenueRate = 0.6) {
+  return rate * (1 - rate / maxRevenueRate);
+}
+
+// Keynesian GDP boost: Returns estimated GDP effect from increased spending
+export function gdpBoostFromSpending(extraSpending, multiplier = 1.4) {
+  return extraSpending * multiplier;
+}
+
+// Dynamic interest rate model based on total debt
+export function getDynamicInterestRate(debt) {
+  if (debt < 1000) return 0.02;
+  if (debt < 2000) return 0.025;
+  if (debt < 3000) return 0.03;
+  return 0.04;
+}


### PR DESCRIPTION
## Summary
- add economic helper utilities
- provide granular calculations helpers
- overhaul dependency model with infrastructure and tax rate effects
- update baseline data exports
- apply dependencies in `App` and allow disabling pension slider
- support disabled sliders in `SliderGroup`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864ff52040083209ddfef2e286282f7