### PR TITLE
Improve slider labels and units

### DIFF
--- a/src/components/SliderGroup.jsx
+++ b/src/components/SliderGroup.jsx
@@ -1,12 +1,26 @@
 import React from 'react';
 
+const labelMap = {
+  vat: 'VAT',
+  localGov: 'Local Government',
+};
+
+function formatLabel(label) {
+  if (labelMap[label]) return labelMap[label];
+  return label
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (str) => str.toUpperCase());
+}
+
 function SliderGroup({ title, sliders, onChange }) {
   return (
     <div className="p-4">
       <h2 className="font-bold mb-2">{title}</h2>
       {sliders.map(({ label, value, min, max, step, disabled }, index) => (
         <div key={index} className="mb-4">
-          <label className="block mb-1">{label}: {value}</label>
+          <label className="block mb-1">
+            {formatLabel(label)}: £{value}bn
+          </label>
           <input
             type="range"
             min={min}


### PR DESCRIPTION
## Summary
- display formatted labels with spaces for slider names
- show values with `£` and `bn` units

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686501387e348320b673b502c813b20c