### PR TITLE
Add future year simulation with debt compounding

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,15 +3,19 @@ import SliderGroup from './components/SliderGroup';
 import OutputSummary from './components/OutputSummary';
 import ChartDisplay from './components/ChartDisplay';
 import { revenueBaseline, spendingBaseline } from './data/fiscalBaseline';
-import { calculateTotals } from './utils/calculations';
+import {
+  getTotalRevenue,
+  getTotalSpending,
+} from './utils/calculations';
 import { applyDependencies } from './utils/dependencyModel';
 
 function App() {
   const [revenue, setRevenue] = useState(revenueBaseline);
   const [spending, setSpending] = useState(spendingBaseline);
+  const [year, setYear] = useState(2024);
+  const [debt, setDebt] = useState(2000); // Starting national debt in £bn
 
   const adjustedState = applyDependencies({ revenue, spending });
-  const totals = calculateTotals(adjustedState.revenue, adjustedState.spending);
 
   const handleRevenueChange = (index, value) => {
     const keys = Object.keys(revenue);
@@ -57,7 +61,29 @@ function App() {
           onChange={handleSpendingChange}
         />
       </div>
-      <OutputSummary totals={totals} />
+      <OutputSummary
+        revenue={adjustedState.revenue}
+        spending={adjustedState.spending}
+        debt={debt}
+        year={year}
+      />
+      <button
+        onClick={() => {
+          const totalRevenue = getTotalRevenue(adjustedState.revenue);
+          const totalSpending = getTotalSpending(adjustedState.spending);
+          const deficit = totalRevenue - totalSpending;
+
+          setDebt((prevDebt) => {
+            const nextDebt = prevDebt + (deficit < 0 ? -deficit : 0);
+            return parseFloat(nextDebt.toFixed(1));
+          });
+
+          setYear((prevYear) => prevYear + 1);
+        }}
+        className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        Simulate Next Year
+      </button>
       <ChartDisplay />
     </div>
   );

--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -1,18 +1,34 @@
 import React from 'react';
+import {
+  getTotalRevenue,
+  getTotalSpending,
+  getDeficit,
+  getDebtInterest,
+} from '../utils/calculations';
+import { getDynamicInterestRate } from '../utils/economics';
 
-function OutputSummary({ totals }) {
-  const { revenue, spending, deficit, debt } = totals;
+const OutputSummary = ({ revenue, spending, debt, year }) => {
+  const totalRevenue = getTotalRevenue(revenue);
+  const totalSpending = getTotalSpending(spending);
+  const deficit = getDeficit(revenue, spending);
+  const rate = getDynamicInterestRate(debt);
+  const interest = getDebtInterest(debt, rate);
+
   return (
-    <div className="p-4 bg-gray-100 rounded">
-      <h2 className="font-bold mb-2">Summary</h2>
-      <ul>
-        <li>Total Revenue: £{revenue}bn</li>
-        <li>Total Spending: £{spending}bn</li>
-        <li>Deficit/Surplus: £{deficit}bn</li>
-        <li>National Debt: £{debt}bn</li>
-      </ul>
+    <div className="p-4 rounded-xl shadow bg-white space-y-2">
+      <h2 className="text-xl font-bold">Budget Summary - {year}</h2>
+      <p>Total Revenue: £{totalRevenue.toFixed(1)}bn</p>
+      <p>Total Spending: £{totalSpending.toFixed(1)}bn</p>
+      <p>
+        {deficit >= 0
+          ? `Surplus: £${deficit.toFixed(1)}bn`
+          : `Deficit: £${(-deficit).toFixed(1)}bn`}
+      </p>
+      <p>Cumulative Debt: £{debt.toFixed(1)}bn</p>
+      <p>Interest Rate: {(rate * 100).toFixed(2)}%</p>
+      <p>Debt Interest: £{interest.toFixed(1)}bn</p>
     </div>
   );
-}
+};
 
 export default OutputSummary;


### PR DESCRIPTION
## Summary
- add year and debt state to track simulation progress
- provide button for simulating the next year with deficit-driven debt accumulation
- enhance `OutputSummary` to display dynamic interest and year
- pass new props from `App.jsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686501c991b88320bbfdfe63ee266735