### PR TITLE
Allow pension adjustments and link unemployment to income tax

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,7 +43,6 @@ function App() {
     min: 0,
     max: spendingBaseline[key] * 2,
     step: 1,
-    disabled: key === 'pensions',
   }));
 
   return (

--- a/src/utils/dependencyModel.js
+++ b/src/utils/dependencyModel.js
@@ -21,5 +21,16 @@ export function applyDependencies(state) {
   const estimatedMax = 350; // theoretical max revenue at optimal rate
   newState.revenue.incomeTax = lafferCurve(taxRate) * estimatedMax;
 
+  // Employment penalty: higher unemployment spending reduces income tax revenue
+  const extraUnemployment =
+    newState.spending.unemployment - fiscalBaseline.spending.unemployment;
+  if (extraUnemployment > 0) {
+    const penalty = extraUnemployment * 0.2;
+    newState.revenue.incomeTax = Math.max(
+      0,
+      newState.revenue.incomeTax - penalty
+    );
+  }
+
   return newState;
 }


### PR DESCRIPTION
## Summary
- re-enable pensions slider by removing its disabled prop
- extend dependency model so unemployment spending reduces income tax revenue

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6865030370bc83208073433f2fc30b01