### PR TITLE
Add simulation history chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import SliderGroup from './components/SliderGroup';
 import OutputSummary from './components/OutputSummary';
 import ChartDisplay from './components/ChartDisplay';
+import HistoryChart from './components/HistoryChart';
 import { revenueBaseline, spendingBaseline } from './data/fiscalBaseline';
 import {
   getTotalRevenue,
@@ -14,8 +15,52 @@ function App() {
   const [spending, setSpending] = useState(spendingBaseline);
   const [year, setYear] = useState(2024);
   const [debt, setDebt] = useState(2000); // Starting national debt in £bn
+  const [history, setHistory] = useState([
+    {
+      year: 2024,
+      revenue: getTotalRevenue(revenueBaseline),
+      spending: getTotalSpending(spendingBaseline),
+      debt: 2000,
+    },
+  ]);
 
   const adjustedState = applyDependencies({ revenue, spending });
+
+  const simulateNextYear = () => {
+    const adjusted = applyDependencies({ revenue, spending });
+    const totalRevenue = getTotalRevenue(adjusted.revenue);
+    const totalSpending = getTotalSpending(adjusted.spending);
+    const deficit = totalRevenue - totalSpending;
+    const updatedDebt = debt + (deficit < 0 ? -deficit : 0);
+
+    setHistory((prev) => [
+      ...prev,
+      {
+        year: year + 1,
+        revenue: totalRevenue,
+        spending: totalSpending,
+        debt: updatedDebt,
+      },
+    ]);
+
+    setDebt(updatedDebt);
+    setYear((prev) => prev + 1);
+  };
+
+  const handleReset = () => {
+    setRevenue(revenueBaseline);
+    setSpending(spendingBaseline);
+    setYear(2024);
+    setDebt(2000);
+    setHistory([
+      {
+        year: 2024,
+        revenue: getTotalRevenue(revenueBaseline),
+        spending: getTotalSpending(spendingBaseline),
+        debt: 2000,
+      },
+    ]);
+  };
 
   const handleRevenueChange = (index, value) => {
     const keys = Object.keys(revenue);
@@ -66,24 +111,22 @@ function App() {
         debt={debt}
         year={year}
       />
-      <button
-        onClick={() => {
-          const totalRevenue = getTotalRevenue(adjustedState.revenue);
-          const totalSpending = getTotalSpending(adjustedState.spending);
-          const deficit = totalRevenue - totalSpending;
-
-          setDebt((prevDebt) => {
-            const nextDebt = prevDebt + (deficit < 0 ? -deficit : 0);
-            return parseFloat(nextDebt.toFixed(1));
-          });
-
-          setYear((prevYear) => prevYear + 1);
-        }}
-        className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-      >
-        Simulate Next Year
-      </button>
+      <div className="flex space-x-2 mt-4">
+        <button
+          onClick={simulateNextYear}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Simulate Next Year
+        </button>
+        <button
+          onClick={handleReset}
+          className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"
+        >
+          Reset
+        </button>
+      </div>
       <ChartDisplay />
+      <HistoryChart history={history} />
     </div>
   );
 }

--- a/src/components/HistoryChart.jsx
+++ b/src/components/HistoryChart.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+const HistoryChart = ({ history }) => {
+  const years = history.map(entry => entry.year);
+  const revenues = history.map(entry => entry.revenue);
+  const spendings = history.map(entry => entry.spending);
+  const debts = history.map(entry => entry.debt);
+
+  const data = {
+    labels: years,
+    datasets: [
+      {
+        label: 'Revenue (£bn)',
+        data: revenues,
+        borderColor: 'green',
+        backgroundColor: 'rgba(0,128,0,0.1)',
+      },
+      {
+        label: 'Spending (£bn)',
+        data: spendings,
+        borderColor: 'red',
+        backgroundColor: 'rgba(255,0,0,0.1)',
+      },
+      {
+        label: 'Debt (£bn)',
+        data: debts,
+        borderColor: 'blue',
+        backgroundColor: 'rgba(0,0,255,0.1)',
+        yAxisID: 'y1',
+      }
+    ]
+  };
+
+  const options = {
+    responsive: true,
+    interaction: {
+      mode: 'index',
+      intersect: false
+    },
+    stacked: false,
+    plugins: {
+      title: {
+        display: true,
+        text: 'Budget Simulation History'
+      }
+    },
+    scales: {
+      y: {
+        type: 'linear',
+        display: true,
+        position: 'left',
+        title: {
+          display: true,
+          text: 'Revenue/Spending (£bn)'
+        }
+      },
+      y1: {
+        type: 'linear',
+        display: true,
+        position: 'right',
+        title: {
+          display: true,
+          text: 'Debt (£bn)'
+        },
+        grid: {
+          drawOnChartArea: false
+        }
+      }
+    }
+  };
+
+  return (
+    <div className="p-4 bg-white shadow rounded-xl">
+      <Line data={data} options={options} />
+    </div>
+  );
+};
+
+export default HistoryChart;


### PR DESCRIPTION
## Summary
- install Chart.js and react-chartjs-2
- create `HistoryChart` for displaying simulation history
- track history in `App` and add reset functionality
- show history chart with simulate and reset buttons

## Testing
- `npm test`
- `npm install chart.js react-chartjs-2` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686503d665488320a557569c02c542d0