### PR TITLE
Introduce department budgets and happiness index

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import SliderGroup from './components/SliderGroup';
+import DepartmentGroup from './components/DepartmentGroup';
 import OutputSummary from './components/OutputSummary';
 import ChartDisplay from './components/ChartDisplay';
 import HistoryChart from './components/HistoryChart';
 import { revenueBaseline, spendingBaseline } from './data/fiscalBaseline';
+import { departmentBudgets } from './data/departmentBudgets';
 import {
   getTotalRevenue,
   getTotalSpending,
@@ -68,9 +70,8 @@ function App() {
     setRevenue(updated);
   };
 
-  const handleSpendingChange = (index, value) => {
-    const keys = Object.keys(spending);
-    const updated = { ...spending, [keys[index]]: value };
+  const handleSpendingChange = (category, value) => {
+    const updated = { ...spending, [category]: value };
     setSpending(updated);
   };
 
@@ -82,13 +83,6 @@ function App() {
     step: 1,
   }));
 
-  const spendingSliders = Object.keys(spending).map((key) => ({
-    label: key,
-    value: spending[key],
-    min: 0,
-    max: spendingBaseline[key] * 2,
-    step: 1,
-  }));
 
   return (
     <div className="max-w-4xl mx-auto p-4">
@@ -99,9 +93,9 @@ function App() {
           sliders={revenueSliders}
           onChange={handleRevenueChange}
         />
-        <SliderGroup
-          title="Spending"
-          sliders={spendingSliders}
+        <DepartmentGroup
+          departments={departmentBudgets}
+          spending={spending}
           onChange={handleSpendingChange}
         />
       </div>

--- a/src/components/DepartmentGroup.jsx
+++ b/src/components/DepartmentGroup.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import SliderGroup from './SliderGroup';
+
+function DepartmentGroup({ departments, spending, onChange }) {
+  return (
+    <div className="space-y-4">
+      {Object.entries(departments).map(([deptName, dept]) => {
+        const categories = dept.categories;
+        const sliders = Object.keys(categories).map((key) => ({
+          label: key,
+          value: spending[key],
+          min: 0,
+          max: categories[key] * 2,
+          step: 1,
+        }));
+        const handleChange = (index, value) => {
+          const keys = Object.keys(categories);
+          onChange(keys[index], value);
+        };
+        return (
+          <div key={deptName} className="border rounded p-2 bg-gray-50">
+            <h3 className="font-semibold mb-2">{deptName}</h3>
+            <SliderGroup title="" sliders={sliders} onChange={handleChange} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default DepartmentGroup;

--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -6,6 +6,7 @@ import {
   getDebtInterest,
 } from '../utils/calculations';
 import { getDynamicInterestRate } from '../utils/economics';
+import { calculateHappinessIndex } from '../utils/qualityOfLife';
 
 const OutputSummary = ({ revenue, spending, debt, year }) => {
   const totalRevenue = getTotalRevenue(revenue);
@@ -13,6 +14,7 @@ const OutputSummary = ({ revenue, spending, debt, year }) => {
   const deficit = getDeficit(revenue, spending);
   const rate = getDynamicInterestRate(debt);
   const interest = getDebtInterest(debt, rate);
+  const happiness = calculateHappinessIndex(spending);
 
   return (
     <div className="p-4 rounded-xl shadow bg-white space-y-2">
@@ -27,6 +29,7 @@ const OutputSummary = ({ revenue, spending, debt, year }) => {
       <p>Cumulative Debt: £{debt.toFixed(1)}bn</p>
       <p>Interest Rate: {(rate * 100).toFixed(2)}%</p>
       <p>Debt Interest: £{interest.toFixed(1)}bn</p>
+      <p>Happiness Index: {happiness}/10</p>
     </div>
   );
 };

--- a/src/data/departmentBudgets.js
+++ b/src/data/departmentBudgets.js
@@ -1,0 +1,49 @@
+import { spending2024 } from './obr2024Budget';
+
+export const departmentBudgets = {
+  'Department of Health and Social Care': {
+    weight: 0.3,
+    categories: {
+      health: spending2024.health,
+    },
+  },
+  'Department for Education': {
+    weight: 0.2,
+    categories: {
+      education: spending2024.education,
+    },
+  },
+  'Ministry of Defence': {
+    weight: 0.05,
+    categories: {
+      defence: spending2024.defence,
+    },
+  },
+  'Department for Work and Pensions': {
+    weight: 0.25,
+    categories: {
+      unemployment: spending2024.unemployment,
+      disability: spending2024.disability,
+      pensions: spending2024.pensions,
+    },
+  },
+  'Housing and Local Government': {
+    weight: 0.15,
+    categories: {
+      housingSupport: spending2024.housingSupport,
+      localGov: spending2024.localGov,
+    },
+  },
+  'Infrastructure and Transport': {
+    weight: 0.05,
+    categories: {
+      infrastructure: spending2024.infrastructure,
+    },
+  },
+  'Debt Interest': {
+    weight: 0,
+    categories: {
+      debtInterest: spending2024.debtInterest,
+    },
+  },
+};

--- a/src/data/happinessIndex.js
+++ b/src/data/happinessIndex.js
@@ -1,0 +1,6 @@
+export const happinessBaseline = {
+  happiness: 7.4,
+  lifeSatisfaction: 7.5,
+  anxiety: 3.1,
+  source: 'ONS (2023) Measures of National Well-being',
+};

--- a/src/utils/qualityOfLife.js
+++ b/src/utils/qualityOfLife.js
@@ -1,0 +1,27 @@
+import { spendingBaseline } from '../data/fiscalBaseline';
+import { happinessBaseline } from '../data/happinessIndex';
+import { departmentBudgets } from '../data/departmentBudgets';
+
+export function calculateHappinessIndex(spending) {
+  let weightedSum = 0;
+  let totalWeight = 0;
+
+  for (const [dept, { categories, weight }] of Object.entries(departmentBudgets)) {
+    let baselineTotal = 0;
+    let currentTotal = 0;
+    for (const category of Object.keys(categories)) {
+      baselineTotal += spendingBaseline[category] || 0;
+      currentTotal += spending[category] || 0;
+    }
+    const ratio = baselineTotal === 0 ? 1 : currentTotal / baselineTotal;
+    weightedSum += ratio * weight;
+    totalWeight += weight;
+  }
+
+  if (totalWeight === 0) {
+    return happinessBaseline.happiness;
+  }
+
+  const index = happinessBaseline.happiness * (weightedSum / totalWeight);
+  return +index.toFixed(2);
+}


### PR DESCRIPTION
## Summary
- group spending categories under UK government departments
- compute a simple happiness index from spending levels
- display department-based spending sliders
- show the happiness index in the budget summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68651fac9e508320be108545e3ae0ab0