### PR TITLE
Keep summary visible and add data source citations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import SliderGroup from './components/SliderGroup';
 import DepartmentGroup from './components/DepartmentGroup';
 import OutputSummary from './components/OutputSummary';
+import SourceCitations from './components/SourceCitations';
 import ChartDisplay from './components/ChartDisplay';
 import HistoryChart from './components/HistoryChart';
 import { revenueBaseline, spendingBaseline } from './data/fiscalBaseline';
@@ -121,6 +122,7 @@ function App() {
       </div>
       <ChartDisplay />
       <HistoryChart history={history} />
+      <SourceCitations />
     </div>
   );
 }

--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -17,7 +17,7 @@ const OutputSummary = ({ revenue, spending, debt, year }) => {
   const happiness = calculateHappinessIndex(spending);
 
   return (
-    <div className="p-4 rounded-xl shadow bg-white space-y-2">
+    <div className="p-4 rounded-xl shadow bg-white space-y-2 fixed top-4 right-4 max-w-xs z-10">
       <h2 className="text-xl font-bold">Budget Summary - {year}</h2>
       <p>Total Revenue: £{totalRevenue.toFixed(1)}bn</p>
       <p>Total Spending: £{totalSpending.toFixed(1)}bn</p>

--- a/src/components/SourceCitations.jsx
+++ b/src/components/SourceCitations.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+/**
+ * Displays data source references directly on the page.
+ */
+function SourceCitations() {
+  return (
+    <div className="mt-8 text-xs text-gray-600 space-y-1">
+      <p>
+        Sources:
+        <a
+          href="https://obr.uk/data/"
+          className="text-blue-600 underline ml-1"
+          target="_blank" rel="noopener noreferrer"
+        >
+          OBR Public Finances Databank (2024)
+        </a>,
+        <a
+          href="https://www.imf.org/external/pubs/ft/spn/2014/spn1402.pdf"
+          className="text-blue-600 underline ml-1"
+          target="_blank" rel="noopener noreferrer"
+        >
+          IMF Fiscal Multipliers (2014)
+        </a>,
+        <a
+          href="https://www.oecd.org/economy/growth/Infrastructure-investment-and-growth.pdf"
+          className="text-blue-600 underline ml-1"
+          target="_blank" rel="noopener noreferrer"
+        >
+          OECD Infrastructure and Growth (2016)
+        </a>,
+        <a
+          href="https://eml.berkeley.edu/~saez/diamond-saezJEP11opttax.pdf"
+          className="text-blue-600 underline ml-1"
+          target="_blank" rel="noopener noreferrer"
+        >
+          Diamond & Saez Optimal Taxation (2011)
+        </a>
+      </p>
+    </div>
+  );
+}
+
+export default SourceCitations;


### PR DESCRIPTION
## Summary
- keep the `OutputSummary` panel fixed to the page so it always stays visible
- add a `SourceCitations` component that links to the data sources
- render citations under the charts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865225daf988320ada327693b18d804