### PR TITLE
Add department budget enforcement

### DIFF
--- a/src/components/DepartmentGroup.jsx
+++ b/src/components/DepartmentGroup.jsx
@@ -6,20 +6,51 @@ function DepartmentGroup({ departments, spending, onChange }) {
     <div className="space-y-4">
       {Object.entries(departments).map(([deptName, dept]) => {
         const categories = dept.categories;
-        const sliders = Object.keys(categories).map((key) => ({
-          label: key,
-          value: spending[key],
-          min: 0,
-          max: categories[key] * 2,
-          step: 1,
-        }));
+        const budget = dept.budget;
+
+        const spent = Object.keys(categories).reduce(
+          (sum, key) => sum + (spending[key] || 0),
+          0
+        );
+
+        const sliders = Object.keys(categories).map((key) => {
+          const otherTotal = spent - (spending[key] || 0);
+          let max = categories[key] * 2;
+          if (budget !== undefined) {
+            max = Math.min(
+              Math.max(spending[key], budget - otherTotal),
+              categories[key] * 2
+            );
+          }
+          return {
+            label: key,
+            value: spending[key],
+            min: 0,
+            max,
+            step: 1,
+          };
+        });
+
         const handleChange = (index, value) => {
           const keys = Object.keys(categories);
-          onChange(keys[index], value);
+          const key = keys[index];
+          const otherTotal = spent - (spending[key] || 0);
+          let newValue = value;
+          if (budget !== undefined) {
+            const maxAllowed = budget - otherTotal;
+            newValue = Math.min(value, maxAllowed);
+          }
+          onChange(key, newValue);
         };
+
         return (
           <div key={deptName} className="border rounded p-2 bg-gray-50">
             <h3 className="font-semibold mb-2">{deptName}</h3>
+            {budget !== undefined && (
+              <p className="text-sm mb-2">
+                Budget: £{budget}bn | Remaining: £{Math.max(budget - spent, 0).toFixed(1)}bn
+              </p>
+            )}
             <SliderGroup title="" sliders={sliders} onChange={handleChange} />
           </div>
         );

--- a/src/data/departmentBudgets.js
+++ b/src/data/departmentBudgets.js
@@ -3,24 +3,31 @@ import { spending2024 } from './obr2024Budget';
 export const departmentBudgets = {
   'Department of Health and Social Care': {
     weight: 0.3,
+    budget: spending2024.health,
     categories: {
       health: spending2024.health,
     },
   },
   'Department for Education': {
     weight: 0.2,
+    budget: spending2024.education,
     categories: {
       education: spending2024.education,
     },
   },
   'Ministry of Defence': {
     weight: 0.05,
+    budget: spending2024.defence,
     categories: {
       defence: spending2024.defence,
     },
   },
   'Department for Work and Pensions': {
     weight: 0.25,
+    budget:
+      spending2024.unemployment +
+      spending2024.disability +
+      spending2024.pensions,
     categories: {
       unemployment: spending2024.unemployment,
       disability: spending2024.disability,
@@ -29,6 +36,7 @@ export const departmentBudgets = {
   },
   'Housing and Local Government': {
     weight: 0.15,
+    budget: spending2024.housingSupport + spending2024.localGov,
     categories: {
       housingSupport: spending2024.housingSupport,
       localGov: spending2024.localGov,
@@ -36,12 +44,14 @@ export const departmentBudgets = {
   },
   'Infrastructure and Transport': {
     weight: 0.05,
+    budget: spending2024.infrastructure,
     categories: {
       infrastructure: spending2024.infrastructure,
     },
   },
   'Debt Interest': {
     weight: 0,
+    budget: spending2024.debtInterest,
     categories: {
       debtInterest: spending2024.debtInterest,
     },


### PR DESCRIPTION
## Summary
- define a `budget` for each department based on OBR 2024 figures
- show remaining budget per department and cap category sliders so total spend does not exceed the allocation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686523cf893c83208f8454e8bc435484