### PR TITLE
Add macroeconomic effects for unemployment and migration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { departmentBudgets } from './data/departmentBudgets';
 import {
   getTotalRevenue,
   getTotalSpending,
+  getDeficit,
 } from './utils/calculations';
 import { applyDependencies } from './utils/dependencyModel';
 
@@ -33,6 +34,7 @@ function App() {
   ]);
 
   const adjustedState = applyDependencies({ revenue, spending });
+  const deficitCurrent = getDeficit(adjustedState.revenue, adjustedState.spending);
 
   const simulateNextYear = () => {
     const adjusted = applyDependencies({ revenue, spending });
@@ -140,6 +142,8 @@ function App() {
         spending={adjustedState.spending}
         debt={debt}
         year={year}
+        deficit={deficitCurrent}
+        gdpGain={adjustedState.gdpGain}
       />
       <div className="flex space-x-2 mt-4">
         <button

--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -5,15 +5,30 @@ import {
   getDeficit,
   getDebtInterest,
 } from '../utils/calculations';
-import { getDynamicInterestRate } from '../utils/economics';
+import {
+  getDynamicInterestRate,
+  getUnemploymentRate,
+  getNetMigration,
+} from '../utils/economics';
+import { macroBaseline } from '../data/macroBaseline';
 import { calculateHappinessIndex } from '../utils/qualityOfLife';
 
-const OutputSummary = ({ revenue, spending, debt, year }) => {
+const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
   const totalRevenue = getTotalRevenue(revenue);
   const totalSpending = getTotalSpending(spending);
-  const deficit = getDeficit(revenue, spending);
-  const rate = getDynamicInterestRate(debt);
+  const balance = deficit !== undefined ? deficit : getDeficit(revenue, spending);
+  const rate = getDynamicInterestRate(debt, balance);
   const interest = getDebtInterest(debt, rate);
+  const unemployment = getUnemploymentRate(
+    macroBaseline.unemploymentRate,
+    gdpGain || 0,
+    macroBaseline.gdp
+  );
+  const migration = getNetMigration(
+    macroBaseline.netMigration,
+    gdpGain || 0,
+    macroBaseline.gdp
+  );
   const happiness = calculateHappinessIndex(spending);
 
   return (
@@ -22,13 +37,15 @@ const OutputSummary = ({ revenue, spending, debt, year }) => {
       <p>Total Revenue: £{totalRevenue.toFixed(1)}bn</p>
       <p>Total Spending: £{totalSpending.toFixed(1)}bn</p>
       <p>
-        {deficit >= 0
-          ? `Surplus: £${deficit.toFixed(1)}bn`
-          : `Deficit: £${(-deficit).toFixed(1)}bn`}
+        {balance >= 0
+          ? `Surplus: £${balance.toFixed(1)}bn`
+          : `Deficit: £${(-balance).toFixed(1)}bn`}
       </p>
       <p>Cumulative Debt: £{debt.toFixed(1)}bn</p>
       <p>Interest Rate: {(rate * 100).toFixed(2)}%</p>
       <p>Debt Interest: £{interest.toFixed(1)}bn</p>
+      <p>Unemployment Rate: {unemployment.toFixed(1)}%</p>
+      <p>Net Migration: {migration.toFixed(2)}m</p>
       <p>Happiness Index: {happiness}/10</p>
     </div>
   );

--- a/src/data/macroBaseline.js
+++ b/src/data/macroBaseline.js
@@ -1,0 +1,10 @@
+export const macroBaseline = {
+  // Approx UK nominal GDP in 2023, £bn
+  gdp: 2500,
+  // Unemployment rate (%) - ONS 2023 Labour Market Statistics
+  unemploymentRate: 4.2,
+  // Net migration (millions) - ONS 2023 provisional estimate
+  netMigration: 0.5,
+  // Bank of England base rate (as decimal)
+  interestRate: 0.035,
+};

--- a/src/utils/dependencyModel.js
+++ b/src/utils/dependencyModel.js
@@ -49,5 +49,5 @@ export function applyDependencies(state) {
   newState.revenue.vat += totalGDPGain * 0.2;
   newState.revenue.corporationTax += totalGDPGain * 0.1;
 
-  return newState;
+  return { ...newState, gdpGain: totalGDPGain };
 }

--- a/src/utils/economics.js
+++ b/src/utils/economics.js
@@ -59,13 +59,49 @@ export function healthGDPBoost(extraHealthSpending, multiplier = 1.3) {
 }
 
 /**
- * Dynamic Interest Rate Model
- * As national debt increases, so does risk and interest burden.
- * These thresholds are illustrative, not predictive.
+ * Dynamic Interest Rate Model with deficit impact
+ * Higher deficits can push interest rates up through crowding-out effects.
+ * See Gale & Orszag (2003) - Economic Effects of Sustained Budget Deficits.
  */
-export function getDynamicInterestRate(debt) {
-  if (debt < 1000) return 0.02;
-  if (debt < 2000) return 0.025;
-  if (debt < 3000) return 0.03;
-  return 0.04;
+export function getDynamicInterestRate(debt, deficit = 0) {
+  let base;
+  if (debt < 1000) base = 0.02;
+  else if (debt < 2000) base = 0.025;
+  else if (debt < 3000) base = 0.03;
+  else base = 0.04;
+
+  // Add 0.01 percentage points for each £100bn of deficit
+  const deficitAdj = Math.max(0, deficit) * 0.0001;
+  return base + deficitAdj;
+}
+
+/**
+ * Unemployment response via Okun's Law.
+ * Roughly 1% extra GDP growth reduces unemployment by about 0.3ppt.
+ * Source: Okun (1962) - Potential GNP: Its Measurement and Significance.
+ */
+export function getUnemploymentRate(
+  baseRate,
+  gdpGain,
+  baselineGDP,
+  okunCoeff = 0.3
+) {
+  const gdpGrowth = gdpGain / baselineGDP;
+  const delta = -okunCoeff * gdpGrowth * 100;
+  return +(baseRate + delta).toFixed(2);
+}
+
+/**
+ * Simple immigration elasticity to economic growth.
+ * Empirical studies suggest positive correlation between GDP growth and net migration.
+ * Elasticity assumed at 0.1 for demonstration (ONS migration data).
+ */
+export function getNetMigration(
+  baseMigration,
+  gdpGain,
+  baselineGDP,
+  elasticity = 0.1
+) {
+  const gdpGrowth = gdpGain / baselineGDP;
+  return +(baseMigration * (1 + elasticity * gdpGrowth)).toFixed(2);
 }


### PR DESCRIPTION
## Summary
- add a `macroBaseline` dataset with GDP, unemployment, migration, and base interest rate
- extend economics utils with functions for deficit-sensitive interest rate, unemployment rate and migration
- return GDP gain from `applyDependencies`
- display unemployment, migration and use deficit-adjusted rate in `OutputSummary`
- pass deficit and GDP gain from `App`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68652ab0122c8320be9ddf133a008f05