### PR TITLE
Add interactive info box

### DIFF
--- a/src/components/InfoBox.jsx
+++ b/src/components/InfoBox.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function InfoBox({ text }) {
+  return (
+    <div className="p-4 bg-yellow-100 rounded mt-4">
+      <p className="text-sm whitespace-pre-line">{text}</p>
+    </div>
+  );
+}
+
+export default InfoBox;


### PR DESCRIPTION
## Summary
- show explanations for sliders in a new `InfoBox`
- update `App.jsx` to track info text and show `InfoBox`
- default text clarifies OBR 2024 figures and economic multipliers

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652cfe791483209914a295edc11d9f