### PR TITLE
Display GDP and macro indicators

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import InfoBox from './components/InfoBox';
 import ChartDisplay from './components/ChartDisplay';
 import HistoryChart from './components/HistoryChart';
 import { revenueBaseline, spendingBaseline } from './data/fiscalBaseline';
+import { macroBaseline } from './data/macroBaseline';
 import { departmentBudgets } from './data/departmentBudgets';
 import {
   getTotalRevenue,
@@ -15,6 +16,11 @@ import {
   getDeficit,
 } from './utils/calculations';
 import { applyDependencies } from './utils/dependencyModel';
+import {
+  getDynamicInterestRate,
+  getUnemploymentRate,
+} from './utils/economics';
+import { calculateHappinessIndex } from './utils/qualityOfLife';
 
 const defaultInfo =
   'This simulator uses baseline figures from the Office for Budget Responsibility\'s March 2024 Public Finances databank. Department budgets are mapped from the same source. Spending multipliers and other assumptions are documented in src/data/assumptions.js.';
@@ -77,6 +83,13 @@ function App() {
 
   const adjustedState = applyDependencies({ revenue, spending });
   const deficitCurrent = getDeficit(adjustedState.revenue, adjustedState.spending);
+  const interestRate = getDynamicInterestRate(debt, deficitCurrent);
+  const unemploymentRate = getUnemploymentRate(
+    macroBaseline.unemploymentRate,
+    adjustedState.gdpGain || 0,
+    macroBaseline.gdp
+  );
+  const happiness = calculateHappinessIndex(adjustedState.spending);
 
   const simulateNextYear = () => {
     const adjusted = applyDependencies({ revenue, spending });
@@ -199,7 +212,12 @@ function App() {
           deficit={deficitCurrent}
           gdpGain={adjustedState.gdpGain}
         />
-        <InfoBox text={infoText} />
+        <InfoBox
+          text={infoText}
+          happiness={happiness}
+          interestRate={interestRate}
+          unemploymentRate={unemploymentRate}
+        />
       </div>
       <div className="flex space-x-2 mt-4">
         <button

--- a/src/components/InfoBox.jsx
+++ b/src/components/InfoBox.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
 
-function InfoBox({ text }) {
+function InfoBox({ text, happiness, interestRate, unemploymentRate }) {
   return (
-    <div className="p-4 bg-yellow-100 rounded">
+    <div className="p-4 bg-yellow-100 rounded space-y-1">
       <p className="text-sm whitespace-pre-line">{text}</p>
+      <p className="text-xs">Happiness Index: {happiness}/10</p>
+      <p className="text-xs">
+        Interest Rate: {(interestRate * 100).toFixed(2)}%
+      </p>
+      <p className="text-xs">
+        Unemployment Rate: {unemploymentRate.toFixed(1)}%
+      </p>
     </div>
   );
 }

--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -30,12 +30,14 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
     macroBaseline.gdp
   );
   const happiness = calculateHappinessIndex(spending);
+  const gdp = macroBaseline.gdp + (gdpGain || 0);
 
   return (
     <div className="p-4 rounded-xl shadow bg-white space-y-2">
       <h2 className="text-xl font-bold">Budget Summary - {year}</h2>
       <p>Total Revenue: £{totalRevenue.toFixed(1)}bn</p>
       <p>Total Spending: £{totalSpending.toFixed(1)}bn</p>
+      <p>GDP: £{gdp.toFixed(1)}bn</p>
       <p>
         {balance >= 0
           ? `Surplus: £${balance.toFixed(1)}bn`


### PR DESCRIPTION
## Summary
- include GDP in the `OutputSummary`
- extend `InfoBox` to show happiness, interest and unemployment
- compute macro indicators in `App` and pass them to `InfoBox`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865329d8600832089cd26015ff38878