### PR TITLE
Improve InfoBox explanations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -217,6 +217,7 @@ function App() {
           happiness={happiness}
           interestRate={interestRate}
           unemploymentRate={unemploymentRate}
+          gdpGain={adjustedState.gdpGain}
         />
       </div>
       <div className="flex space-x-2 mt-4">

--- a/src/components/InfoBox.jsx
+++ b/src/components/InfoBox.jsx
@@ -1,16 +1,26 @@
 import React from 'react';
 
-function InfoBox({ text, happiness, interestRate, unemploymentRate }) {
+function InfoBox({
+  text,
+  happiness,
+  interestRate,
+  unemploymentRate,
+  gdpGain = 0,
+}) {
+  const explanation =
+    'Happiness is weighted using ONS well-being data. ' +
+    'Interest rates rise when debt and deficits increase (Gale & Orszag 2003). ' +
+    'Unemployment follows Okun\'s law – extra GDP growth of £' +
+    gdpGain.toFixed(1) +
+    'bn lowers joblessness.';
+
   return (
     <div className="p-4 bg-yellow-100 rounded space-y-1">
       <p className="text-sm whitespace-pre-line">{text}</p>
+      <p className="text-xs whitespace-pre-line">{explanation}</p>
       <p className="text-xs">Happiness Index: {happiness}/10</p>
-      <p className="text-xs">
-        Interest Rate: {(interestRate * 100).toFixed(2)}%
-      </p>
-      <p className="text-xs">
-        Unemployment Rate: {unemploymentRate.toFixed(1)}%
-      </p>
+      <p className="text-xs">Interest Rate: {(interestRate * 100).toFixed(2)}%</p>
+      <p className="text-xs">Unemployment Rate: {unemploymentRate.toFixed(1)}%</p>
     </div>
   );
 }

--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -38,6 +38,11 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
       <p>Total Revenue: £{totalRevenue.toFixed(1)}bn</p>
       <p>Total Spending: £{totalSpending.toFixed(1)}bn</p>
       <p>GDP: £{gdp.toFixed(1)}bn</p>
+      {gdpGain !== undefined && (
+        <p className="text-xs text-gray-700">
+          GDP change from fiscal policy: £{gdpGain.toFixed(1)}bn
+        </p>
+      )}
       <p>
         {balance >= 0
           ? `Surplus: £${balance.toFixed(1)}bn`


### PR DESCRIPTION
## Summary
- clarify reasons for changes in happiness, interest and unemployment inside the info box
- expose the GDP change due to fiscal multipliers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686533fd92d883208d6d6a681c8e9ff1