### PR TITLE
Add baseline markers and recession metric

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import DepartmentBudgetGroup from './components/DepartmentBudgetGroup';
 import DepartmentGroup from './components/DepartmentGroup';
 import OutputSummary from './components/OutputSummary';
 import SourceCitations from './components/SourceCitations';
+import BaselineKey from './components/BaselineKey';
 import InfoBox from './components/InfoBox';
 import ChartDisplay from './components/ChartDisplay';
 import HistoryChart from './components/HistoryChart';
@@ -173,6 +174,7 @@ function App() {
     min: 0,
     max: revenueBaseline[key] * 2,
     step: 1,
+    baseline: revenueBaseline[key],
   }));
 
   const departmentsWithBudgets = Object.fromEntries(
@@ -236,6 +238,7 @@ function App() {
       </div>
       <ChartDisplay />
       <HistoryChart history={history} />
+      <BaselineKey />
       <SourceCitations />
     </div>
   );

--- a/src/components/BaselineKey.jsx
+++ b/src/components/BaselineKey.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function BaselineKey() {
+  return (
+    <div className="text-xs text-gray-600 mt-2 flex items-center">
+      <span className="inline-block w-2 h-4 bg-blue-500 mr-1"></span>
+      <span>2024 OBR baseline value</span>
+    </div>
+  );
+}
+
+export default BaselineKey;

--- a/src/components/DepartmentBudgetGroup.jsx
+++ b/src/components/DepartmentBudgetGroup.jsx
@@ -8,6 +8,7 @@ function DepartmentBudgetGroup({ departments, budgets, onChange }) {
     min: 0,
     max: dept.budget * 2,
     step: 1,
+    baseline: dept.budget,
   }));
 
   const handleChange = (index, value) => {

--- a/src/components/DepartmentGroup.jsx
+++ b/src/components/DepartmentGroup.jsx
@@ -28,6 +28,7 @@ function DepartmentGroup({ departments, spending, onChange }) {
             min: 0,
             max,
             step: 1,
+            baseline: categories[key],
           };
         });
 

--- a/src/components/InfoBox.jsx
+++ b/src/components/InfoBox.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { macroBaseline } from '../data/macroBaseline';
 
 function InfoBox({
   text,
@@ -14,6 +15,9 @@ function InfoBox({
     gdpGain.toFixed(1) +
     'bn lowers joblessness.';
 
+  const growthRate = (gdpGain / macroBaseline.gdp) * 100;
+  const recessionText = growthRate < 0 ? 'Recession risk from negative growth' : '';
+
   return (
     <div className="p-4 bg-yellow-100 rounded space-y-1">
       <p className="text-sm whitespace-pre-line">{text}</p>
@@ -21,6 +25,10 @@ function InfoBox({
       <p className="text-xs">Happiness Index: {happiness}/10</p>
       <p className="text-xs">Interest Rate: {(interestRate * 100).toFixed(2)}%</p>
       <p className="text-xs">Unemployment Rate: {unemploymentRate.toFixed(1)}%</p>
+      <p className="text-xs">Economic Growth: {growthRate.toFixed(2)}%</p>
+      {recessionText && (
+        <p className="text-xs text-red-600">{recessionText}</p>
+      )}
     </div>
   );
 }

--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -31,6 +31,7 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
   );
   const happiness = calculateHappinessIndex(spending);
   const gdp = macroBaseline.gdp + (gdpGain || 0);
+  const growthRate = ((gdpGain || 0) / macroBaseline.gdp) * 100;
 
   return (
     <div className="p-4 rounded-xl shadow bg-white space-y-2">
@@ -54,6 +55,7 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
       <p>Unemployment Rate: {unemployment.toFixed(1)}%</p>
       <p>Net Migration: {migration.toFixed(2)}m</p>
       <p>Happiness Index: {happiness}/10</p>
+      <p>Economic Growth: {growthRate.toFixed(2)}%</p>
     </div>
   );
 };

--- a/src/components/SliderGroup.jsx
+++ b/src/components/SliderGroup.jsx
@@ -16,23 +16,36 @@ function SliderGroup({ title, sliders, onChange }) {
   return (
     <div className="p-4">
       <h2 className="font-bold mb-2">{title}</h2>
-      {sliders.map(({ label, value, min, max, step, disabled }, index) => (
-        <div key={index} className="mb-4">
-          <label className="block mb-1">
-            {formatLabel(label)}: £{value}bn
-          </label>
-          <input
-            type="range"
-            min={min}
-            max={max}
-            step={step}
-            value={value}
-            onChange={(e) => onChange(index, Number(e.target.value))}
-            className="w-full"
-            disabled={disabled}
-          />
-        </div>
-      ))}
+      {sliders.map(
+        ({ label, value, min, max, step, baseline, disabled }, index) => {
+          const percent = baseline !== undefined ? ((baseline - min) / (max - min)) * 100 : null;
+          return (
+            <div key={index} className="mb-4">
+              <label className="block mb-1">
+                {formatLabel(label)}: £{value}bn
+              </label>
+              <div className="relative">
+                <input
+                  type="range"
+                  min={min}
+                  max={max}
+                  step={step}
+                  value={value}
+                  onChange={(e) => onChange(index, Number(e.target.value))}
+                  className="w-full"
+                  disabled={disabled}
+                />
+                {percent !== null && (
+                  <div
+                    className="absolute top-1/2 -translate-y-1/2 w-0.5 h-4 bg-blue-500"
+                    style={{ left: `${percent}%` }}
+                  />
+                )}
+              </div>
+            </div>
+          );
+        }
+      )}
     </div>
   );
 }

--- a/src/utils/dependencyModel.js
+++ b/src/utils/dependencyModel.js
@@ -25,19 +25,19 @@ export function applyDependencies(state) {
   // --- GDP Boosts from Spending ---
   let totalGDPGain = 0;
 
-  if (extraUnemp > 0) {
+  if (extraUnemp !== 0) {
     totalGDPGain += unemploymentGDPBoost(extraUnemp); // IMF 2014
   }
 
-  if (extraInfra > 0) {
+  if (extraInfra !== 0) {
     totalGDPGain += infrastructureGDPBoost(extraInfra); // OECD 2016
   }
 
-  if (extraEducation > 0) {
+  if (extraEducation !== 0) {
     totalGDPGain += educationGDPBoost(extraEducation); // Hanushek & Woessmann 2015
   }
 
-  if (extraHealth > 0) {
+  if (extraHealth !== 0) {
     totalGDPGain += healthGDPBoost(extraHealth); // WHO/Bloom 2008
   }
 


### PR DESCRIPTION
## Summary
- display a vertical marker on each slider to show the 2024 OBR baseline
- list a key explaining the baseline marker
- show economic growth percentage and recession warnings
- allow GDP to drop when spending is cut

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686535e7767c832083139f489047beac