### PR TITLE
Add additional socio-economic metrics

### DIFF
--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -12,6 +12,16 @@ import {
 } from '../utils/economics';
 import { macroBaseline } from '../data/macroBaseline';
 import { calculateHappinessIndex } from '../utils/qualityOfLife';
+import {
+  getLabourParticipation,
+  getProductivity,
+  getInflationRate,
+  getInequality,
+  getCrimeRate,
+  getLifeExpectancy,
+  getEducationOutcome,
+  getEmissionsIndex,
+} from '../utils/additionalMetrics';
 
 const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
   const totalRevenue = getTotalRevenue(revenue);
@@ -30,6 +40,14 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
     macroBaseline.gdp
   );
   const happiness = calculateHappinessIndex(spending);
+  const participation = getLabourParticipation(spending);
+  const productivity = getProductivity(spending);
+  const inflation = getInflationRate(balance, gdpGain || 0);
+  const inequality = getInequality(spending, revenue);
+  const crime = getCrimeRate(unemployment, inequality, spending);
+  const lifeExpectancy = getLifeExpectancy(spending);
+  const educationIndex = getEducationOutcome(spending);
+  const emissions = getEmissionsIndex(spending, revenue);
   const gdp = macroBaseline.gdp + (gdpGain || 0);
   const growthRate = ((gdpGain || 0) / macroBaseline.gdp) * 100;
 
@@ -56,6 +74,14 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
       <p>Net Migration: {migration.toFixed(2)}m</p>
       <p>Happiness Index: {happiness}/10</p>
       <p>Economic Growth: {growthRate.toFixed(2)}%</p>
+      <p>Labour Participation: {participation.toFixed(1)}%</p>
+      <p>Productivity Index: {productivity.toFixed(1)}</p>
+      <p>Inflation Rate: {(inflation * 100).toFixed(2)}%</p>
+      <p>Inequality (Gini): {inequality.toFixed(3)}</p>
+      <p>Crime Rate: {crime.toFixed(1)}</p>
+      <p>Life Expectancy: {lifeExpectancy.toFixed(1)} years</p>
+      <p>Education Index: {educationIndex.toFixed(2)}</p>
+      <p>Emissions Index: {emissions.toFixed(1)}</p>
     </div>
   );
 };

--- a/src/data/additionalBaseline.js
+++ b/src/data/additionalBaseline.js
@@ -1,0 +1,10 @@
+export const additionalBaseline = {
+  labourParticipation: 79.0, // % of working-age population
+  productivity: 100, // index
+  inflation: 0.03, // 3%
+  gini: 0.35,
+  crimeRate: 75, // incidents per 1000 population (index)
+  lifeExpectancy: 81, // years
+  educationIndex: 0.8, // index 0-1
+  emissionsIndex: 100, // index
+};

--- a/src/utils/additionalMetrics.js
+++ b/src/utils/additionalMetrics.js
@@ -1,0 +1,87 @@
+import { spendingBaseline, revenueBaseline } from '../data/fiscalBaseline';
+import { additionalBaseline } from '../data/additionalBaseline';
+import { macroBaseline } from '../data/macroBaseline';
+
+export function getLabourParticipation(spending) {
+  const extraHealth = spending.health - spendingBaseline.health;
+  const extraEducation = spending.education - spendingBaseline.education;
+  const extraPensions = spending.pensions - spendingBaseline.pensions;
+  const rate =
+    additionalBaseline.labourParticipation +
+    0.02 * extraHealth +
+    0.015 * extraEducation -
+    0.01 * extraPensions;
+  return +rate.toFixed(2);
+}
+
+export function getProductivity(spending) {
+  const extraInfra = spending.infrastructure - spendingBaseline.infrastructure;
+  const extraScience = spending.science - spendingBaseline.science;
+  const extraEducation = spending.education - spendingBaseline.education;
+  const index =
+    additionalBaseline.productivity +
+    0.1 * extraInfra +
+    0.1 * extraScience +
+    0.05 * extraEducation;
+  return +index.toFixed(2);
+}
+
+export function getInflationRate(deficit, gdpGain) {
+  const rate =
+    additionalBaseline.inflation +
+    deficit * 0.0001 +
+    gdpGain * 0.00005;
+  return +rate.toFixed(3);
+}
+
+export function getInequality(spending, revenue) {
+  const extraWelfare =
+    (spending.unemployment - spendingBaseline.unemployment) +
+    (spending.housingSupport - spendingBaseline.housingSupport);
+  const vatChange = revenue.vat - revenueBaseline.vat;
+  const rate =
+    additionalBaseline.gini -
+    0.0005 * extraWelfare +
+    0.0001 * vatChange;
+  return +rate.toFixed(3);
+}
+
+export function getCrimeRate(unemploymentRate, inequality, spending) {
+  const extraPolicing = spending.homeOffice - spendingBaseline.homeOffice;
+  const rate =
+    additionalBaseline.crimeRate +
+    (unemploymentRate - macroBaseline.unemploymentRate) * 2 +
+    (inequality - additionalBaseline.gini) * 100 -
+    0.1 * extraPolicing;
+  return +rate.toFixed(1);
+}
+
+export function getLifeExpectancy(spending) {
+  const extraHealth = spending.health - spendingBaseline.health;
+  const extraEnvironment = spending.environment - spendingBaseline.environment;
+  const expectancy =
+    additionalBaseline.lifeExpectancy +
+    0.02 * extraHealth +
+    0.01 * extraEnvironment;
+  return +expectancy.toFixed(2);
+}
+
+export function getEducationOutcome(spending) {
+  const extraEducation = spending.education - spendingBaseline.education;
+  const extraScience = spending.science - spendingBaseline.science;
+  const index =
+    additionalBaseline.educationIndex +
+    0.05 * extraEducation +
+    0.02 * extraScience;
+  return +index.toFixed(3);
+}
+
+export function getEmissionsIndex(spending, revenue) {
+  const extraEnvironment = spending.environment - spendingBaseline.environment;
+  const fuelDutyChange = revenue.fuelDuty - revenueBaseline.fuelDuty;
+  const index =
+    additionalBaseline.emissionsIndex -
+    0.05 * extraEnvironment -
+    0.02 * fuelDutyChange;
+  return +index.toFixed(1);
+}


### PR DESCRIPTION
## Summary
- introduce baseline values for socio-economic metrics
- compute new metrics like labour participation, productivity, inflation, inequality, crime, life expectancy, education index and emissions index
- display these metrics in `OutputSummary`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686537b85fc8832084e1081ac570e0fb