### PR TITLE
Improve budget tooltips and remove info box

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,12 +5,12 @@ import DepartmentGroup from './components/DepartmentGroup';
 import OutputSummary from './components/OutputSummary';
 import SourceCitations from './components/SourceCitations';
 import BaselineKey from './components/BaselineKey';
-import InfoBox from './components/InfoBox';
 import ChartDisplay from './components/ChartDisplay';
 import HistoryChart from './components/HistoryChart';
 import { revenueBaseline, spendingBaseline } from './data/fiscalBaseline';
 import { macroBaseline } from './data/macroBaseline';
 import { departmentBudgets } from './data/departmentBudgets';
+import { revenueInfo } from './data/infoText';
 import {
   getTotalRevenue,
   getTotalSpending,
@@ -23,46 +23,6 @@ import {
 } from './utils/economics';
 import { calculateHappinessIndex } from './utils/qualityOfLife';
 
-const defaultInfo =
-  'This simulator uses baseline figures from the Office for Budget Responsibility\'s March 2024 Public Finances databank. Department budgets are mapped from the same source. Spending multipliers and other assumptions are documented in src/data/assumptions.js.';
-
-const revenueInfo = {
-  incomeTax:
-    'Income tax revenue. Increasing this slider raises total revenue. Baseline from OBR 2024.',
-  nationalInsurance:
-    'National Insurance contributions. Baseline from OBR 2024.',
-  vat: 'Value Added Tax receipts based on OBR 2024.',
-  corporationTax: 'Corporation tax revenue.',
-  fuelDuty: 'Fuel duty receipts.',
-  alcoholDuty: 'Alcohol duty receipts.',
-  tobaccoDuty: 'Tobacco duty receipts.',
-  other: 'Other government revenue.',
-};
-
-const spendingInfo = {
-  unemployment:
-    'Unemployment benefits. Extra spending boosts GDP using a 1.3 multiplier (IMF 2014), which increases tax revenues.',
-  infrastructure:
-    'Infrastructure investment. Extra spending boosts GDP with a multiplier around 2.0 (OECD 2016).',
-  education:
-    'Education spending. Higher funding improves long‑term GDP (Hanushek & Woessmann 2015).',
-  health:
-    'Health/NHS budget. Increased spending can raise productivity with a ~1.3 multiplier (WHO/Bloom 2008).',
-};
-
-const budgetInfo = {
-  'Department of Health and Social Care':
-    'Sets the overall health budget. Lowering it scales the health category down proportionally.',
-  'Department for Education':
-    'Controls the education budget. Reducing it shrinks education spending.',
-  'Ministry of Defence': 'Total defence budget.',
-  'Department for Work and Pensions':
-    'Welfare budget covering unemployment, disability and pensions. Reduced budgets scale those categories.',
-  'Housing and Local Government':
-    'Budget for housing support and grants to local government.',
-  'Infrastructure and Transport': 'Infrastructure and transport budget.',
-};
-
 function App() {
   const [revenue, setRevenue] = useState(revenueBaseline);
   const [spending, setSpending] = useState(spendingBaseline);
@@ -72,7 +32,6 @@ function App() {
   const [budgets, setBudgets] = useState(initialBudgets);
   const [year, setYear] = useState(2024);
   const [debt, setDebt] = useState(2000); // Starting national debt in £bn
-  const [infoText, setInfoText] = useState(defaultInfo);
   const [history, setHistory] = useState([
     {
       year: 2024,
@@ -127,7 +86,6 @@ function App() {
         debt: 2000,
       },
     ]);
-    setInfoText(defaultInfo);
   };
 
   const handleRevenueChange = (index, value) => {
@@ -135,8 +93,6 @@ function App() {
     const key = keys[index];
     const updated = { ...revenue, [key]: value };
     setRevenue(updated);
-    const desc = revenueInfo[key] || `${key} revenue.`;
-    setInfoText(`${desc} Set to £${value}bn.`);
   };
 
   const handleBudgetChange = (deptName, value) => {
@@ -153,19 +109,13 @@ function App() {
         updatedSpending[key] = +(spending[key] * ratio).toFixed(1);
       });
       setSpending(updatedSpending);
-      const desc = budgetInfo[deptName] || `${deptName} budget.`;
-      setInfoText(`${desc} Reduced to £${value}bn and category spend scaled.`);
       return;
     }
-    const desc = budgetInfo[deptName] || `${deptName} budget.`;
-    setInfoText(`${desc} Set to £${value}bn.`);
   };
 
   const handleSpendingChange = (category, value) => {
     const updated = { ...spending, [category]: value };
     setSpending(updated);
-    const desc = spendingInfo[category] || `${category} spending.`;
-    setInfoText(`${desc} Set to £${value}bn.`);
   };
 
   const revenueSliders = Object.keys(revenue).map((key) => ({
@@ -175,6 +125,7 @@ function App() {
     max: revenueBaseline[key] * 2,
     step: 1,
     baseline: revenueBaseline[key],
+    info: revenueInfo[key],
   }));
 
   const departmentsWithBudgets = Object.fromEntries(
@@ -212,13 +163,6 @@ function App() {
           debt={debt}
           year={year}
           deficit={deficitCurrent}
-          gdpGain={adjustedState.gdpGain}
-        />
-        <InfoBox
-          text={infoText}
-          happiness={happiness}
-          interestRate={interestRate}
-          unemploymentRate={unemploymentRate}
           gdpGain={adjustedState.gdpGain}
         />
       </div>

--- a/src/components/DepartmentBudgetGroup.jsx
+++ b/src/components/DepartmentBudgetGroup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SliderGroup from './SliderGroup';
+import { budgetInfo } from '../data/infoText';
 
 function DepartmentBudgetGroup({ departments, budgets, onChange }) {
   const sliders = Object.entries(departments).map(([name, dept]) => ({
@@ -9,6 +10,7 @@ function DepartmentBudgetGroup({ departments, budgets, onChange }) {
     max: dept.budget * 2,
     step: 1,
     baseline: dept.budget,
+    info: budgetInfo[name],
   }));
 
   const handleChange = (index, value) => {

--- a/src/components/DepartmentGroup.jsx
+++ b/src/components/DepartmentGroup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SliderGroup from './SliderGroup';
+import { spendingInfo } from '../data/infoText';
 
 function DepartmentGroup({ departments, spending, onChange }) {
   return (
@@ -29,6 +30,7 @@ function DepartmentGroup({ departments, spending, onChange }) {
             max,
             step: 1,
             baseline: categories[key],
+            info: spendingInfo[key],
           };
         });
 

--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -23,6 +23,29 @@ import {
   getEmissionsIndex,
 } from '../utils/additionalMetrics';
 
+const summaryInfo = {
+  revenue: 'Sum of all revenue categories.',
+  spending: 'Combined value of all spending categories.',
+  gdp: 'Gross domestic product after policy changes.',
+  gdpChange: 'Change in GDP resulting from your fiscal policy.',
+  balance: 'Difference between revenue and spending.',
+  debt: 'Existing national debt plus new borrowing.',
+  interestRate: 'Estimated borrowing cost based on debt levels.',
+  interest: 'Annual cost of servicing the national debt.',
+  unemployment: 'Projected unemployment after policy.',
+  migration: 'Estimated net migration.',
+  happiness: 'Quality of life score weighted by spending.',
+  growth: 'Annual economic growth rate.',
+  participation: 'Share of working-age people employed.',
+  productivity: 'Output per worker relative to baseline.',
+  inflation: 'Estimated price growth from policy.',
+  inequality: 'Income inequality measured by the Gini coefficient.',
+  crime: 'Crime index influenced by unemployment and inequality.',
+  life: 'Average life expectancy.',
+  education: 'Education outcomes index.',
+  emissions: 'Carbon emissions relative to baseline.',
+};
+
 const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
   const totalRevenue = getTotalRevenue(revenue);
   const totalSpending = getTotalSpending(spending);
@@ -54,34 +77,90 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
   return (
     <div className="p-4 rounded-xl shadow bg-white space-y-2">
       <h2 className="text-xl font-bold">Budget Summary - {year}</h2>
-      <p>Total Revenue: £{totalRevenue.toFixed(1)}bn</p>
-      <p>Total Spending: £{totalSpending.toFixed(1)}bn</p>
-      <p>GDP: £{gdp.toFixed(1)}bn</p>
+      <p>
+        Total Revenue: £{totalRevenue.toFixed(1)}bn
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.revenue}>?</span>
+      </p>
+      <p>
+        Total Spending: £{totalSpending.toFixed(1)}bn
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.spending}>?</span>
+      </p>
+      <p>
+        GDP: £{gdp.toFixed(1)}bn
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.gdp}>?</span>
+      </p>
       {gdpGain !== undefined && (
         <p className="text-xs text-gray-700">
           GDP change from fiscal policy: £{gdpGain.toFixed(1)}bn
+          <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.gdpChange}>?</span>
         </p>
       )}
       <p>
         {balance >= 0
           ? `Surplus: £${balance.toFixed(1)}bn`
           : `Deficit: £${(-balance).toFixed(1)}bn`}
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.balance}>?</span>
       </p>
-      <p>Cumulative Debt: £{debt.toFixed(1)}bn</p>
-      <p>Interest Rate: {(rate * 100).toFixed(2)}%</p>
-      <p>Debt Interest: £{interest.toFixed(1)}bn</p>
-      <p>Unemployment Rate: {unemployment.toFixed(1)}%</p>
-      <p>Net Migration: {migration.toFixed(2)}m</p>
-      <p>Happiness Index: {happiness}/10</p>
-      <p>Economic Growth: {growthRate.toFixed(2)}%</p>
-      <p>Labour Participation: {participation.toFixed(1)}%</p>
-      <p>Productivity Index: {productivity.toFixed(1)}</p>
-      <p>Inflation Rate: {(inflation * 100).toFixed(2)}%</p>
-      <p>Inequality (Gini): {inequality.toFixed(3)}</p>
-      <p>Crime Rate: {crime.toFixed(1)}</p>
-      <p>Life Expectancy: {lifeExpectancy.toFixed(1)} years</p>
-      <p>Education Index: {educationIndex.toFixed(2)}</p>
-      <p>Emissions Index: {emissions.toFixed(1)}</p>
+      <p>
+        Cumulative Debt: £{debt.toFixed(1)}bn
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.debt}>?</span>
+      </p>
+      <p>
+        Interest Rate: {(rate * 100).toFixed(2)}%
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.interestRate}>?</span>
+      </p>
+      <p>
+        Debt Interest: £{interest.toFixed(1)}bn
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.interest}>?</span>
+      </p>
+      <p>
+        Unemployment Rate: {unemployment.toFixed(1)}%
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.unemployment}>?</span>
+      </p>
+      <p>
+        Net Migration: {migration.toFixed(2)}m
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.migration}>?</span>
+      </p>
+      <p>
+        Happiness Index: {happiness}/10
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.happiness}>?</span>
+      </p>
+      <p>
+        Economic Growth: {growthRate.toFixed(2)}%
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.growth}>?</span>
+      </p>
+      <p>
+        Labour Participation: {participation.toFixed(1)}%
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.participation}>?</span>
+      </p>
+      <p>
+        Productivity Index: {productivity.toFixed(1)}
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.productivity}>?</span>
+      </p>
+      <p>
+        Inflation Rate: {(inflation * 100).toFixed(2)}%
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.inflation}>?</span>
+      </p>
+      <p>
+        Inequality (Gini): {inequality.toFixed(3)}
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.inequality}>?</span>
+      </p>
+      <p>
+        Crime Rate: {crime.toFixed(1)}
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.crime}>?</span>
+      </p>
+      <p>
+        Life Expectancy: {lifeExpectancy.toFixed(1)} years
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.life}>?</span>
+      </p>
+      <p>
+        Education Index: {educationIndex.toFixed(2)}
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.education}>?</span>
+      </p>
+      <p>
+        Emissions Index: {emissions.toFixed(1)}
+        <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.emissions}>?</span>
+      </p>
     </div>
   );
 };

--- a/src/components/SliderGroup.jsx
+++ b/src/components/SliderGroup.jsx
@@ -17,7 +17,7 @@ function SliderGroup({ title, sliders, onChange }) {
     <div className="p-4">
       <h2 className="font-bold mb-2">{title}</h2>
       {sliders.map(
-        ({ label, value, min, max, step, baseline, disabled }, index) => {
+        ({ label, value, min, max, step, baseline, disabled, info }, index) => {
           const percent = baseline !== undefined ? ((baseline - min) / (max - min)) * 100 : null;
           return (
             <div key={index} className="mb-4">
@@ -41,10 +41,13 @@ function SliderGroup({ title, sliders, onChange }) {
                     style={{ left: `${percent}%` }}
                   />
                 )}
-              </div>
             </div>
-          );
-        }
+            {info && (
+              <p className="text-xs text-gray-600 mt-1 whitespace-pre-line">{info}</p>
+            )}
+          </div>
+        );
+      }
       )}
     </div>
   );

--- a/src/data/infoText.js
+++ b/src/data/infoText.js
@@ -1,0 +1,36 @@
+export const revenueInfo = {
+  incomeTax:
+    'Income tax revenue. Increasing this slider raises total revenue. Baseline from OBR 2024.',
+  nationalInsurance:
+    'National Insurance contributions. Baseline from OBR 2024.',
+  vat: 'Value Added Tax receipts based on OBR 2024.',
+  corporationTax: 'Corporation tax revenue.',
+  fuelDuty: 'Fuel duty receipts.',
+  alcoholDuty: 'Alcohol duty receipts.',
+  tobaccoDuty: 'Tobacco duty receipts.',
+  other: 'Other government revenue.',
+};
+
+export const spendingInfo = {
+  unemployment:
+    'Unemployment benefits. Extra spending boosts GDP using a 1.3 multiplier (IMF 2014), which increases tax revenues.',
+  infrastructure:
+    'Infrastructure investment. Extra spending boosts GDP with a multiplier around 2.0 (OECD 2016).',
+  education:
+    'Education spending. Higher funding improves long‑term GDP (Hanushek & Woessmann 2015).',
+  health:
+    'Health/NHS budget. Increased spending can raise productivity with a ~1.3 multiplier (WHO/Bloom 2008).',
+};
+
+export const budgetInfo = {
+  'Department of Health and Social Care':
+    'Sets the overall health budget. Lowering it scales the health category down proportionally.',
+  'Department for Education':
+    'Controls the education budget. Reducing it shrinks education spending.',
+  'Ministry of Defence': 'Total defence budget.',
+  'Department for Work and Pensions':
+    'Welfare budget covering unemployment, disability and pensions. Reduced budgets scale those categories.',
+  'Housing and Local Government':
+    'Budget for housing support and grants to local government.',
+  'Infrastructure and Transport': 'Infrastructure and transport budget.',
+};


### PR DESCRIPTION
## Summary
- remove `InfoBox` from UI
- add `infoText` dataset for slider explanations
- show info text below sliders
- add tooltip help icons to the budget summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68653d5408bc832094027a706d63c338