### PR TITLE
Refine app styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -137,8 +137,8 @@ function App() {
 
 
   return (
-    <div className="max-w-4xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">UK Budget Simulator</h1>
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-xl font-bold mb-4">UK Budget Simulator</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <SliderGroup
           title="Revenue"
@@ -156,7 +156,7 @@ function App() {
         spending={spending}
         onChange={handleSpendingChange}
       />
-      <div className="fixed top-4 right-4 max-w-xs z-10 space-y-2">
+      <div className="fixed top-4 right-10 max-w-xs z-10 space-y-2">
         <OutputSummary
           revenue={adjustedState.revenue}
           spending={adjustedState.spending}

--- a/src/components/ChartDisplay.jsx
+++ b/src/components/ChartDisplay.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 function ChartDisplay() {
   // Placeholder for chart implementation
   return (
-    <div className="p-4">
-      <h2 className="font-bold mb-2">Charts</h2>
+    <div className="p-4 text-sm">
+      <h2 className="font-semibold text-base mb-2">Charts</h2>
       <p>Chart visualizations will appear here.</p>
     </div>
   );

--- a/src/components/DepartmentBudgetGroup.jsx
+++ b/src/components/DepartmentBudgetGroup.jsx
@@ -20,8 +20,8 @@ function DepartmentBudgetGroup({ departments, budgets, onChange }) {
   };
 
   return (
-    <div className="p-4">
-      <h2 className="font-bold mb-2">Department Budgets</h2>
+    <div className="p-4 text-sm">
+      <h2 className="font-semibold text-base mb-2">Department Budgets</h2>
       <SliderGroup title="" sliders={sliders} onChange={handleChange} />
     </div>
   );

--- a/src/components/DepartmentGroup.jsx
+++ b/src/components/DepartmentGroup.jsx
@@ -47,7 +47,7 @@ function DepartmentGroup({ departments, spending, onChange }) {
         };
 
         return (
-          <div key={deptName} className="border rounded p-2 bg-gray-50">
+          <div key={deptName} className="border rounded p-2 bg-gray-50 text-sm">
             <h3 className="font-semibold mb-2">{deptName}</h3>
             {budget !== undefined && (
               <p className="text-sm mb-2">

--- a/src/components/HistoryChart.jsx
+++ b/src/components/HistoryChart.jsx
@@ -91,7 +91,7 @@ const HistoryChart = ({ history }) => {
   };
 
   return (
-    <div className="p-4 bg-white shadow rounded-xl">
+    <div className="p-4 bg-white shadow rounded-xl text-sm">
       <Line data={data} options={options} />
     </div>
   );

--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -75,8 +75,8 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
   const growthRate = ((gdpGain || 0) / macroBaseline.gdp) * 100;
 
   return (
-    <div className="p-4 rounded-xl shadow bg-white space-y-2">
-      <h2 className="text-xl font-bold">Budget Summary - {year}</h2>
+    <div className="p-4 rounded-xl shadow bg-white space-y-2 text-sm">
+      <h2 className="text-lg font-bold">Budget Summary - {year}</h2>
       <p>
         Total Revenue: £{totalRevenue.toFixed(1)}bn
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.revenue}>?</span>

--- a/src/components/SliderGroup.jsx
+++ b/src/components/SliderGroup.jsx
@@ -14,8 +14,8 @@ function formatLabel(label) {
 
 function SliderGroup({ title, sliders, onChange }) {
   return (
-    <div className="p-4">
-      <h2 className="font-bold mb-2">{title}</h2>
+    <div className="p-4 text-sm">
+      <h2 className="font-semibold text-base mb-2">{title}</h2>
       {sliders.map(
         ({ label, value, min, max, step, baseline, disabled, info }, index) => {
           const percent = baseline !== undefined ? ((baseline - min) / (max - min)) * 100 : null;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply font-sans text-gray-800 text-sm;
+  font-family: Arial, Helvetica, sans-serif;
+}


### PR DESCRIPTION
## Summary
- use Arial-based font and smaller body text
- narrow overall layout and reposition budget summary sidebar
- shrink headings and components for a neater look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686540619710832080b0c4496297ee80