### PR TITLE
Color code budget summary metrics

### DIFF
--- a/src/components/OutputSummary.jsx
+++ b/src/components/OutputSummary.jsx
@@ -22,6 +22,7 @@ import {
   getEducationOutcome,
   getEmissionsIndex,
 } from '../utils/additionalMetrics';
+import { additionalBaseline } from '../data/additionalBaseline';
 
 const summaryInfo = {
   revenue: 'Sum of all revenue categories.',
@@ -74,6 +75,30 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
   const gdp = macroBaseline.gdp + (gdpGain || 0);
   const growthRate = ((gdpGain || 0) / macroBaseline.gdp) * 100;
 
+  const good = 'text-green-600';
+  const bad = 'text-red-600';
+
+  const balanceClass = balance >= 0 ? good : bad;
+  const gdpGainClass = gdpGain > 0 ? good : gdpGain < 0 ? bad : '';
+  const unemploymentClass =
+    unemployment <= macroBaseline.unemploymentRate ? good : bad;
+  const interestClass = rate <= macroBaseline.interestRate ? good : bad;
+  const inflationClass =
+    inflation <= additionalBaseline.inflation ? good : bad;
+  const growthClass = growthRate >= 0 ? good : bad;
+  const inequalityClass = inequality <= additionalBaseline.gini ? good : bad;
+  const crimeClass = crime <= additionalBaseline.crimeRate ? good : bad;
+  const lifeClass =
+    lifeExpectancy >= additionalBaseline.lifeExpectancy ? good : bad;
+  const educationClass =
+    educationIndex >= additionalBaseline.educationIndex ? good : bad;
+  const participationClass =
+    participation >= additionalBaseline.labourParticipation ? good : bad;
+  const productivityClass =
+    productivity >= additionalBaseline.productivity ? good : bad;
+  const emissionsClass =
+    emissions <= additionalBaseline.emissionsIndex ? good : bad;
+
   return (
     <div className="p-4 rounded-xl shadow bg-white space-y-2 text-sm">
       <h2 className="text-lg font-bold">Budget Summary - {year}</h2>
@@ -90,15 +115,17 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.gdp}>?</span>
       </p>
       {gdpGain !== undefined && (
-        <p className="text-xs text-gray-700">
+        <p className={`text-xs ${gdpGainClass}`}>
           GDP change from fiscal policy: £{gdpGain.toFixed(1)}bn
           <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.gdpChange}>?</span>
         </p>
       )}
       <p>
-        {balance >= 0
-          ? `Surplus: £${balance.toFixed(1)}bn`
-          : `Deficit: £${(-balance).toFixed(1)}bn`}
+        <span className={balanceClass}>
+          {balance >= 0
+            ? `Surplus: £${balance.toFixed(1)}bn`
+            : `Deficit: £${(-balance).toFixed(1)}bn`}
+        </span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.balance}>?</span>
       </p>
       <p>
@@ -106,7 +133,7 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.debt}>?</span>
       </p>
       <p>
-        Interest Rate: {(rate * 100).toFixed(2)}%
+        <span className={interestClass}>Interest Rate: {(rate * 100).toFixed(2)}%</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.interestRate}>?</span>
       </p>
       <p>
@@ -114,7 +141,7 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.interest}>?</span>
       </p>
       <p>
-        Unemployment Rate: {unemployment.toFixed(1)}%
+        <span className={unemploymentClass}>Unemployment Rate: {unemployment.toFixed(1)}%</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.unemployment}>?</span>
       </p>
       <p>
@@ -126,39 +153,39 @@ const OutputSummary = ({ revenue, spending, debt, year, deficit, gdpGain }) => {
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.happiness}>?</span>
       </p>
       <p>
-        Economic Growth: {growthRate.toFixed(2)}%
+        <span className={growthClass}>Economic Growth: {growthRate.toFixed(2)}%</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.growth}>?</span>
       </p>
       <p>
-        Labour Participation: {participation.toFixed(1)}%
+        <span className={participationClass}>Labour Participation: {participation.toFixed(1)}%</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.participation}>?</span>
       </p>
       <p>
-        Productivity Index: {productivity.toFixed(1)}
+        <span className={productivityClass}>Productivity Index: {productivity.toFixed(1)}</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.productivity}>?</span>
       </p>
       <p>
-        Inflation Rate: {(inflation * 100).toFixed(2)}%
+        <span className={inflationClass}>Inflation Rate: {(inflation * 100).toFixed(2)}%</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.inflation}>?</span>
       </p>
       <p>
-        Inequality (Gini): {inequality.toFixed(3)}
+        <span className={inequalityClass}>Inequality (Gini): {inequality.toFixed(3)}</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.inequality}>?</span>
       </p>
       <p>
-        Crime Rate: {crime.toFixed(1)}
+        <span className={crimeClass}>Crime Rate: {crime.toFixed(1)}</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.crime}>?</span>
       </p>
       <p>
-        Life Expectancy: {lifeExpectancy.toFixed(1)} years
+        <span className={lifeClass}>Life Expectancy: {lifeExpectancy.toFixed(1)} years</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.life}>?</span>
       </p>
       <p>
-        Education Index: {educationIndex.toFixed(2)}
+        <span className={educationClass}>Education Index: {educationIndex.toFixed(2)}</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.education}>?</span>
       </p>
       <p>
-        Emissions Index: {emissions.toFixed(1)}
+        <span className={emissionsClass}>Emissions Index: {emissions.toFixed(1)}</span>
         <span className="ml-1 text-blue-600 cursor-help" title={summaryInfo.emissions}>?</span>
       </p>
     </div>


### PR DESCRIPTION
## Summary
- import additionalBaseline data
- add helper variables for good/bad classes
- color metrics red or green based on baseline comparisons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686542b491a48320886e02dad4d8d9c3